### PR TITLE
Added OWASP-Community Slack link and Routing Instructions for Ubuntu

### DIFF
--- a/BuildEnvironment.md
+++ b/BuildEnvironment.md
@@ -154,6 +154,14 @@ Execute the following command on the Kali Linux machine or another virtual machi
 ```
 # ifconfig eth0 add 192.168.1.101 broadcast 192.168.1.255
 ```
+
+If you're on Ubuntu (18.04) :
+
+```
+# sudo apt-get install net-tools (if you don't have it installed)
+# sudo ifconfig ens33 add 192.168.1.101 broadcast 192.168.1.255
+```
+
 You should now see a virtual interface named eth0:0. <br>
 ```
 eth0:0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ The IoTGoat Project is a deliberately insecure firmware based on OpenWrt. The pr
  ![IoT Top 10 2018](/images/OWASP-IoT-Top-10-2018-final.jpg)
 
 
-To get started with developing IoTGoat challenges, review the [Build Environment guidance](BuildEnvironment.md) page. If a crucial challenge idea is missing, please reach out to the project leaders below. Be sure to join the OWASP Slack team, then join the #iot-security for news on upcoming project meetings and updates.
+To get started with developing IoTGoat challenges, review the [Build Environment Guidance](BuildEnvironment.md) page. If a crucial challenge idea is missing, please reach out to the project leaders below. Be sure to join the [OWASP Slack team](https://join.slack.com/t/owasp/shared_invite/enQtNDI5MzgxMDQ2MTAwLTEyNzIzYWQ2NDZiMGIwNmJhYzYxZDJiNTM0ZmZiZmJlY2EwZmMwYjAyNmJjNzQxNzMyMWY4OTk3ZTQ0MzFhMDY), then join the **#iot-security** for news on upcoming project meetings and updates.
 
 #### Project leaders
-Aaron Guzman @scriptingxss <br>
-Fotios Chantzis <br>
-Paulino Calderon
+
+* Aaron Guzman (@scriptingxss)
+* Fotios Chantzis
+* Paulino Calderon


### PR DESCRIPTION
## Changes : 

* Added **#owasp-community** slack invite link to `README.md`
* Added routing instructions for Ubuntu 18.04

Instructions tested in : _(should work in all ubuntu versions)_

```
dev@ubuntu:~$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 18.04.2 LTS
Release:	18.04
Codename:	bionic
dev@ubuntu:~$ 
```
